### PR TITLE
Disable debian unstable builds (temporary)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,8 @@ env:
   - DISTRIB=alpine RELEASE=edge REPOSITORY=olbat/alpine TAGS=edge,latest
   - DISTRIB=debian RELEASE=stable REPOSITORY=olbat/debian TAGS=stable,stretch,9.x,9,latest
   - DISTRIB=debian RELEASE=testing REPOSITORY=olbat/debian TAGS=testing,buster,10.x,10
-  - DISTRIB=debian RELEASE=unstable REPOSITORY=olbat/debian TAGS=unstable,sid
+  # FIXME: temporary disabled (see https://travis-ci.org/olbat/docker-base-images/jobs/293213182)
+  #- DISTRIB=debian RELEASE=unstable REPOSITORY=olbat/debian TAGS=unstable,sid
   - DISTRIB=ubuntu RELEASE=precise REPOSITORY=olbat/ubuntu TAGS=precise,12.04
   - DISTRIB=ubuntu RELEASE=trusty REPOSITORY=olbat/ubuntu TAGS=trusty,14.04
   - DISTRIB=ubuntu RELEASE=xenial REPOSITORY=olbat/ubuntu TAGS=xenial,16.04,latest


### PR DESCRIPTION
Debootstrap seems to be broken for this version